### PR TITLE
misspellings: actually point to bash shell if the default shell is different

### DIFF
--- a/git-automation.sh
+++ b/git-automation.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 echo "NOTE -> git and gh must be installed to use this"
 echo "Welcome to Git & GitHub Automation :"


### PR DESCRIPTION
No space in "#!/bin/bash" :)